### PR TITLE
GUI logging enhancements

### DIFF
--- a/pm2hw/gui/components/__init__.py
+++ b/pm2hw/gui/components/__init__.py
@@ -8,4 +8,5 @@ from .help import open_about, HelpDialog
 from .linker import refresh_linkers
 from .status import add_progress, make_status, set_status
 from .gamelist import GameList
+from .protocol import ProtocolDialog
 from .preferences import PreferencesDialog

--- a/pm2hw/gui/components/help.py
+++ b/pm2hw/gui/components/help.py
@@ -14,7 +14,7 @@ from tkinter.font import Font
 from .linker import DittoFlash
 from .status import _make_status
 from .gamelist import GameList, ROM
-from ..widgets import RichText, ScrollFrame
+from ..widgets import Dialog, RichText, ScrollFrame
 from ..i18n import _
 from ... import __version__ as main_version
 from ...linkers import BaseLinker
@@ -67,8 +67,9 @@ class DummyROM(ROM):
 				return info
 		return games.ROM(games.Status.unidentified, code, name, crc)
 
-class HelpDialog(simpledialog.Dialog):
+class HelpDialog(Dialog):
 	def body(self, master: tk.Frame):
+		super().body(master)
 		self.topics: Dict[str, RichText] = {}
 		self.html_handlers = {
 			"a": self.link_handler,

--- a/pm2hw/gui/components/library.py
+++ b/pm2hw/gui/components/library.py
@@ -87,7 +87,7 @@ class Library(ttk.Frame):
 		self.tree.tag_configure("LibraryListEntryFont", font=f)
 		f = font.nametofont("LibraryListCategoryFont")
 		self.tree.tag_configure("LibraryListCategoryFont", font=f)
-	
+
 		scroll_x = ttk.Scrollbar(self, orient=tk.HORIZONTAL, command=self.tree.xview)
 		scroll_y = ttk.Scrollbar(self, orient=tk.VERTICAL, command=self.tree.yview)
 		self.tree.configure(xscrollcommand=scroll_x.set, yscrollcommand=scroll_y.set)

--- a/pm2hw/gui/components/protocol.py
+++ b/pm2hw/gui/components/protocol.py
@@ -52,12 +52,23 @@ class ProtocolDialog(Dialog):
 		self.window = ttk.PanedWindow(master, orient=tk.HORIZONTAL)
 		self.window.pack(fill=tk.BOTH, expand=True)
 		
-		self.log_pane = ttk.Treeview(self.window,
+		frm = ttk.Frame(self.window)
+		self.log_pane = ttk.Treeview(frm,
 			show="tree",
 			selectmode="browse",
 			takefocus=True,
 		)
 		self.log_pane.bind("<<TreeviewSelect>>", self.show_info)
+
+		scroll_x = ttk.Scrollbar(frm, orient=tk.HORIZONTAL, command=self.log_pane.xview)
+		scroll_y = ttk.Scrollbar(frm, orient=tk.VERTICAL, command=self.log_pane.yview)
+		self.log_pane.configure(xscrollcommand=scroll_x.set, yscrollcommand=scroll_y.set)
+
+		self.log_pane.grid(column=0, row=0, sticky=tk.NSEW)
+		scroll_y.grid(column=1, row=0, sticky="nes")
+		scroll_x.grid(column=0, row=1, sticky="esw")
+		frm.columnconfigure(0, weight=1)
+		frm.rowconfigure(0, weight=1)
 
 		self.hex_pane = RichText(self.window,
 			style="HexView.RichText",
@@ -67,8 +78,8 @@ class ProtocolDialog(Dialog):
 			spacing3=1,
 		)
 
-		self.window.add(self.log_pane)
-		self.window.add(self.hex_pane.top, weight=1)
+		self.window.add(frm, weight=3)
+		self.window.add(self.hex_pane.top, weight=2)
 
 		# Set up logger
 		self.records = {}

--- a/pm2hw/gui/components/protocol.py
+++ b/pm2hw/gui/components/protocol.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2021 Sapphire Becker (logicplace.com)
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Dict, List, Tuple
+
+from ..widgets import Dialog, RichText
+from ... import logger
+from ...locales import natural_size
+
+# TODO: localization
+
+class DataFormatter(logger.Formatter):
+	def __init__(self, unkfmt="", datefmt=None, *, in_fmt, out_fmt) -> None:
+		super().__init__(unkfmt, datefmt)
+		self._fmts = {
+			"<": logger.Formatter(in_fmt, datefmt),
+			">": logger.Formatter(out_fmt, datefmt)
+		}
+
+	def format(self, record: logger.LogRecord):
+		# Assume all are PROTOCOL.DATA records
+		record.dir, *record.bytes = record.msg.split(" ")
+		record.msg = logger.SubtypedMessage("", "DATA")
+		record.size = len(record.bytes)
+		record.natsize = natural_size(record.size)
+		formatter = self._fmts.get(record.dir, super())
+		return formatter.format(record)
+
+
+proto_formatter = logger.MonospacePrefixFormatter("[{asctime}] ")
+data_formatter = DataFormatter(
+	"[{asctime}] {dir} {natsize}",
+	in_fmt="[{asctime}] Received {natsize}",
+	out_fmt="[{asctime}] Sent {natsize}"
+)
+
+def filter_non_proto(record: logger.LogRecord):
+	return record.levelno == logger.PROTOCOL
+
+class ProtocolDialog(Dialog):
+	record_index = 0
+	records: Dict[str, logger.LogRecord]
+
+	def body(self, master: tk.Frame):
+		super().body(master)
+		master.pack_configure(fill=tk.BOTH, expand=True)
+		self.window = ttk.PanedWindow(master, orient=tk.HORIZONTAL)
+		self.window.pack(fill=tk.BOTH, expand=True)
+		
+		self.log_pane = ttk.Treeview(self.window,
+			show="tree",
+			selectmode="browse",
+			takefocus=True,
+		)
+		self.log_pane.bind("<<TreeviewSelect>>", self.show_info)
+
+		self.hex_pane = RichText(self.window,
+			style="HexView.RichText",
+			style_tags=["cell-even", "cell-odd", "header-even", "header-odd"],
+			state="readonly",
+			orient=tk.HORIZONTAL,
+			spacing3=1,
+		)
+
+		self.window.add(self.log_pane)
+		self.window.add(self.hex_pane.top, weight=1)
+
+		# Set up logger
+		self.records = {}
+		self.initial_level = logger.get_effective_level()
+		logger.set_level(logger.PROTOCOL)
+
+		proto_handler = logger.Handler(logger.PROTOCOL, raw_handler=self.add_proto_entry)
+		proto_handler.add_filter(filter_non_proto)
+		proto_handler.add_subtype_filter(logger.PROTOCOL, reject=["DATA"])
+		logger.add_handler(proto_handler)
+
+		data_handler = logger.Handler(logger.PROTOCOL, raw_handler=self.add_data_entry)
+		data_handler.add_filter(filter_non_proto)
+		data_handler.add_subtype_filter(logger.PROTOCOL, allow=["DATA"])
+		logger.add_handler(data_handler)
+
+		# logger.protocol("<", data=b"testing")
+		# logger.protocol(">", data=b"0123456789abcdef" * 100)
+
+	def _add_log_entry(self, record: logger.LogRecord, formatter: logger.Formatter, tag: str):
+		iid = f"r{self.record_index}"
+		self.log_pane.insert("", tk.END, iid, text=formatter.format(record), tags=tag)
+		self.records[iid] = record
+		self.record_index += 1
+
+	def add_proto_entry(self, record: logger.LogRecord):
+		self._add_log_entry(record, proto_formatter, "proto")
+
+	def add_data_entry(self, record: logger.LogRecord):
+		self._add_log_entry(record, data_formatter, "data")
+
+	def show_info(self, *_):
+		sel = self.log_pane.selection()
+		if not sel:
+			return
+		record = self.records[sel[0]]
+		data = getattr(record, "bytes", [])
+		if data:
+			self.display_bytes(record.bytes)
+		else:
+			# Non-data logs aren't selectable
+			self.log_pane.selection_remove(sel)
+
+	def display_bytes(self, b: List[str]):
+		# List of two character strings, each being the hex of a byte
+		hp = self.hex_pane
+		hp.clear()
+
+		size = len(b)
+		width = len(f"{size:X}")
+		if width % 2 != 0:
+			width += 1
+
+		hp.insert(tk.END, " " * width, "header-odd")
+		for x in [
+			"00", "01", "02", "03", "04", "05", "06", "07",
+			"08", "09", "0A", "0B", "0C", "0D", "0E", "0F",
+		][:size]:
+			hp.insert(tk.END, "\u200b")
+			hp.insert(tk.END, x, "header-odd")
+		hp.insert(tk.END, "\n")
+
+		for l, i in enumerate(range(0, size, 16)):
+			eo = "odd" if l % 2 else "even"
+			hp.insert(tk.END, f"{i:0{width}X}", f"header-{eo}")
+			tag = f"cell-{eo}"
+			for x in b[i:i+16]:
+				hp.insert(tk.END, "\u200b")
+				hp.insert(tk.END, x, tag)
+			hp.insert(tk.END, "\n")
+
+	def grab_set(self):
+		# Prevent this window from preventing interaction with other windows
+		pass
+
+	def buttonbox(self):
+		# Disable buttons
+		pass
+
+	def cancel(self, event=None):
+		super().cancel(event)
+		logger.set_level(self.initial_level)
+

--- a/pm2hw/gui/themes/base.py
+++ b/pm2hw/gui/themes/base.py
@@ -251,6 +251,44 @@ class BaseTheme(metaclass=MetaTheme):
 				"foreground": "#600",
 			}
 		},
+		"critical.Console.RichText": {
+			"configure": {
+				"foreground": "#600",
+			}
+		},
+		"HexView.RichText": {
+			"configure": {
+				"font": "RichTextConsoleFont",
+				"wrap": tk.NONE,
+				"tabs": "1m",
+			}
+		},
+		"cell-even.HexView.RichText": {
+			"configure": {
+				"borderwidth": 1,
+				"relief": tk.RAISED,
+			}
+		},
+		"cell-odd.HexView.RichText": {
+			"configure": {
+				"borderwidth": 1,
+				"relief": tk.RIDGE,
+			}
+		},
+		"header-even.HexView.RichText": {
+			"configure": {
+				"font": "RichTextBoldConsoleFont",
+				"borderwidth": 1,
+				"relief": tk.RAISED,
+			}
+		},
+		"header-odd.HexView.RichText": {
+			"configure": {
+				"font": "RichTextBoldConsoleFont",
+				"borderwidth": 1,
+				"relief": tk.RIDGE,
+			}
+		},
 		"OrderedListItem.TFrame": {
 			"configure": {
 				"borderwidth": 2,
@@ -378,6 +416,11 @@ class BaseTheme(metaclass=MetaTheme):
 	RichTextConsoleFont = {
 		"family": ["Consolas", "Courier New"],
 		"size": 12,
+	}
+	RichTextBoldConsoleFont = {
+		"family": ["Consolas", "Courier New"],
+		"size": 12,
+		"weight": font.BOLD,
 	}
 	RichTextH1Font = {
 		"family": "Arial",

--- a/pm2hw/gui/themes/colorized.py
+++ b/pm2hw/gui/themes/colorized.py
@@ -101,6 +101,12 @@ class ColorizedTheme(BaseTheme):
 					"foreground": self.error,
 				}
 			}),
+			ovr("critical.Console.RichText", {
+				"configure": {
+					"background": self.console.bg,
+					"foreground": self.error,
+				}
+			}),
 			ovr("TButton", {
 				"configure": {
 					"background": self.inside.bg,

--- a/pm2hw/gui/widgets/__init__.py
+++ b/pm2hw/gui/widgets/__init__.py
@@ -5,5 +5,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from .menu import Menu
+from .dialog import Dialog
 from .richtext import RichText
 from .scrollframe import ScrollFrame

--- a/pm2hw/gui/widgets/dialog.py
+++ b/pm2hw/gui/widgets/dialog.py
@@ -1,0 +1,16 @@
+import tkinter as tk
+from tkinter import ttk, simpledialog
+
+simpledialog.Button = ttk.Button
+simpledialog.Frame = ttk.Frame
+simpledialog.Label = ttk.Label
+
+class Dialog(simpledialog.Dialog):
+	def body(self, master: tk.Frame):
+		self.bind("<<ThemeChanged>>", self.update_styling)
+		self.update_styling()
+
+	def update_styling(self, *_):
+		s = ttk.Style()
+		bg = s.configure("TFrame", "background")
+		self.configure(background=bg)

--- a/pm2hw/gui/widgets/menu.py
+++ b/pm2hw/gui/widgets/menu.py
@@ -87,8 +87,8 @@ class Menu(tk.Menu):
 			# TODO: might be a problem if menus are destroyed
 			var.trace_add("write", partial(self._updater, var))
 			self.label_vars[self.count] = var  # TODO: insufficient for dynamic menus
+			opts["label"], opts["underline"] = self._get_underline(var.get())
 		self.count += 1
-		opts["label"], opts["underline"] = self._get_underline(var.get())
 		super().add(itemType, **opts, **cfg)
 
 	def replace(self, index, itemType, cnf: dict, *, label: str = "", **kw):

--- a/pm2hw/locales/en/LC_MESSAGES/pm2hw.po
+++ b/pm2hw/locales/en/LC_MESSAGES/pm2hw.po
@@ -360,6 +360,27 @@ msgstr "_Multicart"
 msgid "window.menu.view.log"
 msgstr "_Log"
 
+msgid "window.menu.view.log.show"
+msgstr "_Show pane"
+
+msgid "window.menu.view.log.info"
+msgstr "_Info"
+
+msgid "window.menu.view.log.verbose"
+msgstr "_Verbose"
+
+msgid "window.menu.view.log.debug"
+msgstr "_Debug"
+
+msgid "window.menu.view.log.warn"
+msgstr "_Warning"
+
+msgid "window.menu.view.log.error"
+msgstr "_Error"
+
+msgid "window.menu.view.log.protocol"
+msgstr "Open _protocol viewer"
+
 msgid "window.menu.help"
 msgstr "_Help"
 
@@ -374,6 +395,9 @@ msgstr "_About"
 
 msgid "window.preferences.title"
 msgstr "pm2hw - Preferences"
+
+msgid "window.protocol.title"
+msgstr "pm2hw - Protocol viewer"
 
 msgid "window.title"
 msgstr "pm2hw - Pokémon mini Flashing Utility"

--- a/pm2hw/logger.py
+++ b/pm2hw/logger.py
@@ -41,17 +41,17 @@ def get_level_from_name(name: str):
 view = "cli"
 logger = logging.getLogger(logger_name)
 
-class SubtypedMessage:
-	def __init__(self, msg: str, subtype: str):
-		self._msg = msg
-		self._subtype = subtype.upper()
+class SubtypedMessage(str):
+	_subtype: str
+
+	def __new__(cls, msg: str, subtype: str):
+		ret = super().__new__(cls, msg)
+		ret._subtype = subtype.upper()
+		return ret
 
 	@property
 	def subtype(self):
 		return self._subtype
-
-	def __str__(self):
-		return str(self._msg)
 
 class Formatter(logging.Formatter):
 	default_time_format = "%H:%M:%S"
@@ -197,7 +197,7 @@ def add_log_only_handler():
 def protocol(msg, data=None, **kwargs):
 	if is_enabled_for(PROTOCOL):
 		if data:
-			msg = " ".join((msg, *(f"{b:02x}" for b in data)))
+			msg = SubtypedMessage(" ".join((msg, *(f"{b:02x}" for b in data))), "DATA")
 		else:
 			msg = msg.format(**kwargs)
 		logger.log(PROTOCOL, msg)


### PR DESCRIPTION
Changes the View -> Log menu entry to a submenu with log filters and an entry to open the protocol viewer.
Also implements said protocol viewer.

The log filters are cosmetic, all the messages are logged regardless and simply are hidden/shown in the log pane based on the selections. Protocol messages are not logged until the viewer is open and are cleared once it's closed, tho.

This needs a bit more testing before I merge. Basic usage tests + ensure that protocol log memory is actually freed when the viewer is closed.